### PR TITLE
Fix typo in EXPORT command

### DIFF
--- a/assignments/ha-04/readme.md
+++ b/assignments/ha-04/readme.md
@@ -22,7 +22,7 @@ You will be prompted for your password.  Once you have logged in, you can
 run the following command to access the `RISC-V` toolchain:
 
 ```bash
-$ export PATH=$PATH:/user/local/riscv/bin
+$ export PATH=$PATH:/usr/local/riscv/bin
 ```
 
 The list of tools that you will/might use in this assignment are:


### PR DESCRIPTION
The handout currently adds `/user/local/riscv/bin` to the user's path. However, the correct directory is `/usr/local/riscv/bin`.